### PR TITLE
Fix compilation errors for Quicklisp.

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -21,7 +21,7 @@
   (:export :start-http :stop-http :stop-thread :list-workers :list-requests))
 
 (defpackage :myweb.util
-  (:use :cl :local-time :trivial-utf-8)
+  (:use :cl :local-time)
   (:export :parse-request :read-utf-8-string :response-write :get-param :get-header :http-response :file-response :html-template :log-info :log-warning :log-error))
 
 (defpackage :myweb.handler

--- a/util.lisp
+++ b/util.lisp
@@ -38,7 +38,7 @@
     (trivial-utf-8:utf-8-bytes-to-string buffer)))
 
 (defun response-write (text stream)
-  (trivial-utf-8:write-utf-8-bytes text stream))
+  (trivial-utf-8::write-utf-8-bytes text stream))
 
 (defun parse-get-header (header stream)
   (cons "GET" 


### PR DESCRIPTION
Package MYWEB.UTIL no longer uses package TRIVIAL-UTF-8, since that causes a conflict for symbol READ-UTF-8-STRING.

TRIVIAL-UTF-8 no longer exports WRITE-UTF-8-BYTES.